### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/vuln-code-copilot-autofix/main.go
+++ b/vuln-code-copilot-autofix/main.go
@@ -4,13 +4,16 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func unzip(f string) {
 	r, _ := zip.OpenReader(f)
 	for _, f := range r.File {
-		p, _ := filepath.Abs(f.Name)
-		// BAD: This could overwrite any file on the file system
-		os.WriteFile(p, []byte("present"), 0666)
+		if !strings.Contains(f.Name, "..") {
+			p, _ := filepath.Abs(f.Name)
+			// GOOD: Check that path does not contain ".." before using it
+			os.WriteFile(p, []byte("present"), 0666)
+		}
 	}
 }


### PR DESCRIPTION
Fixes [https://github.com/uta8a/playground/security/code-scanning/1](https://github.com/uta8a/playground/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths extracted from the zip archive do not contain any directory traversal elements such as "`..`". This can be achieved by validating the paths before using them in file system operations.

- First, we need to check if the file name contains any "`..`" elements.
- If the file name is safe, we proceed with writing the file.
- If the file name is unsafe, we skip the file or handle it appropriately.

We will modify the `unzip` function to include this validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
